### PR TITLE
calling for maven to check that Jetty can serve JSTL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 *.swp
 *.log
 *~
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
       <version>3.1.0</version>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-annotations</artifactId>
       <version>${jetty-version}</version>

--- a/src/test/java/org/eclipse/jetty/demo/JstlTest.java
+++ b/src/test/java/org/eclipse/jetty/demo/JstlTest.java
@@ -1,0 +1,45 @@
+package org.eclipse.jetty.demo;
+
+import org.eclipse.jetty.server.Server;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class JstlTest {
+
+    protected Server server;
+    private Main main;
+
+    @Before
+    public void aJettyServer() throws Exception {
+        main = new Main(8080);
+        main.start();
+    }
+
+    @After
+    public void stopServer() throws Exception {
+        main.stop();
+    }
+
+    @Test
+    public void canServeJspWithTaglib() throws Exception {
+        assertThat(resourceWithUrl("http://localhost:8080/test/jstl.jsp"), containsString("10"));
+    }
+
+    public String resourceWithUrl(String uri) throws Exception {
+        URL url = new URL( uri );
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        InputStream inputStream = connection.getInputStream();
+        byte[] response = new byte[ inputStream.available() ];
+        inputStream.read(response);
+
+        return new String(response);
+    }
+}


### PR DESCRIPTION
Hi,

Will you help make this test pass via maven 3?

This test passes in Intelij IDEA 14.1 Community Edition but in the command line via maven 3 I'm getting the famous error message

org.apache.jasper.JasperException: The absolute uri: http://java.sun.com/jsp/jstl/core cannot be resolved

Thanks in advance